### PR TITLE
[suggestion] switch to light code highlighting in the doc

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -8,7 +8,7 @@ contentDir = "../saddle-docs/target/mdoc"
 
 pygmentsCodeFences = true
 pygmentsCodefencesGuessSyntax = true
-pygmentsStyle = "monokai"
+pygmentsStyle = "friendly"
 pygmentsUseClasses = false
 
 # Controls how many words are printed in the content summary on the docs homepage.


### PR DESCRIPTION
Dark code highlighting on the light website theme is very contrasting. I think that switching to light code highlighting would improve the doc site look.
Here is an example with the "friendly" pygment style. There are many other good looking light ones available. Here is the reference link https://xyproto.github.io/splash/docs/longer/all.html .
![image](https://user-images.githubusercontent.com/11885535/143658430-0e6a5bf5-cd38-4fe1-b5ba-da18455f9d48.png)


