### PR TITLE
Feature/reindex with fill

### DIFF
--- a/saddle-core/src/main/scala/org/saddle/package.scala
+++ b/saddle-core/src/main/scala/org/saddle/package.scala
@@ -455,4 +455,11 @@ package object saddle {
 
   }
 
+  /** Filling method for NA values. Non-sealed because could add more variants
+    * in the future.
+    */
+  // private constructor to prevent public extensions
+  abstract class FillMethod private[saddle] ()
+  case object FillForward extends FillMethod() {}
+  case object FillBackward extends FillMethod() {}
 }

--- a/saddle-core/src/test/scala/org/saddle/Arbitraries.scala
+++ b/saddle-core/src/test/scala/org/saddle/Arbitraries.scala
@@ -1,0 +1,8 @@
+package org.saddle
+
+import org.scalacheck.Arbitrary
+import org.scalacheck.Gen
+
+object Arbitraries {
+    implicit val fillArbitrary: Arbitrary[FillMethod] = Arbitrary(Gen.oneOf(FillForward, FillBackward))
+}

--- a/saddle-core/src/test/scala/org/saddle/SeriesArbitraries.scala
+++ b/saddle-core/src/test/scala/org/saddle/SeriesArbitraries.scala
@@ -45,4 +45,9 @@ object SeriesArbitraries {
       idx <- Gen.listOfN(n, Gen.choose(0, 5))
     } yield Series(Vec(lst: _*), Index(idx: _*))
 
+  def seriesIntDoubleWithUnorderedIdxAndDupAndNAs: Gen[Series[Int, Double]] =
+    dupSeriesDoubleWithNA
+
+  def seriesIntDoubleMonotonicWithNAs: Gen[Series[Int, Double]] =
+    seriesDoubleWithNA
 }

--- a/saddle-time/src/test/scala/time/SeriesCheck.scala
+++ b/saddle-time/src/test/scala/time/SeriesCheck.scala
@@ -392,7 +392,6 @@ class SeriesCheck extends Specification with ScalaCheck {
 
     "reindex works" in {
       implicit val ser = Arbitrary(SeriesArbitraries.seriesDateTimeDoubleNoDup)
-
       forAll { (s1: Series[DateTime, Double], s2: Series[DateTime, Double]) =>
         s1.reindex(s2.index).index must_== s2.index
       }


### PR DESCRIPTION
Add a `Series.reindex(idx, fillMethod, limit)` overload to support reindexing with keys that aren't part of the original series's index.
Works similarly to [pandas's reindex](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.reindex.html).
Mentioned in discussion #360.