### PR TITLE
Fetch tags during website publish

### DIFF
--- a/.github/workflows/sonatype.yml
+++ b/.github/workflows/sonatype.yml
@@ -10,6 +10,7 @@ jobs:
       - uses: actions/checkout@v2
         with: 
           submodules: recursive
+          fetch-depth: 0
       - uses: actions/setup-java@v2
         with:
           distribution: temurin


### PR DESCRIPTION
The versions on the website seem to indicate that tags are missing during website publishing, tripping dynver 
![CleanShot 2024-11-18 at 13 29 43@2x](https://github.com/user-attachments/assets/4f4bd0ce-06ee-42aa-a5fa-d22999328445)
